### PR TITLE
feat: add env library selection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ async function setup() {
     srcDir: prompt.srcDir,
     nativeWind: prompt.installNativeWind,
     envEnabled: prompt.envEnabled,
+    envLibrary: prompt.envLibrary,
     template: prompt.template,
     disableGit: prompt.disableGit,
     skipInstall: false,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -123,6 +123,17 @@ export default async function prompts() {
 
   questions.push({
     type: "list",
+    name: "envLibrary",
+    message: "Please choose the library you would like to use for environment variables:",
+    when: (answers: Answers) => Boolean(answers.envEnabled),
+    choices: [
+      { name: "React Native Config", value: "react-native-config" },
+      { name: "React Native Dotenv", value: "react-native-dotenv" },
+    ],
+  });
+
+  questions.push({
+    type: "list",
     name: "reactNativeVersion",
     message: "Which React Native version would you like to use?",
     choices: [

--- a/src/react-native-lab.ts
+++ b/src/react-native-lab.ts
@@ -19,6 +19,7 @@ export default async function createReactNative({
   nativeWind,
   srcDir,
   envEnabled,
+  envLibrary,
   disableGit,
   skipInstall,
   template,
@@ -29,6 +30,7 @@ export default async function createReactNative({
   srcDir: boolean;
   nativeWind: boolean;
   envEnabled: boolean;
+  envLibrary: string;
   disableGit?: boolean;
   skipInstall: boolean;
   template: TemplateType;
@@ -102,6 +104,7 @@ export default async function createReactNative({
     root,
     packageManager,
     envEnabled,
+    envLibrary,
     template,
     srcDir,
     nativeWind,

--- a/src/template.ts
+++ b/src/template.ts
@@ -44,6 +44,7 @@ export const installTemplate = async ({
   root,
   packageManager,
   envEnabled,
+  envLibrary,
   template,
   srcDir,
   nativeWind,
@@ -152,6 +153,9 @@ export const installTemplate = async ({
     }
   }
 
+  const isDotenv = envEnabled && envLibrary === "react-native-dotenv";
+  const isReactNativeConfig = envEnabled && envLibrary === "react-native-config";
+
   /**
    * Replace code in babel.config.js with custom import alias code.
    */
@@ -163,7 +167,7 @@ module.exports = {
   }],
   plugins: [
   ${
-    envEnabled
+    isDotenv
       ? `[
       "module:react-native-dotenv",
       {
@@ -262,10 +266,17 @@ module.exports = {
     },
   };
 
-  if (envEnabled) {
+  if (isDotenv) {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
       "react-native-dotenv": "^3.4.11",
+    };
+  }
+
+  if (isReactNativeConfig) {
+    packageJson.devDependencies = {
+      ...packageJson.devDependencies,
+      "react-native-config": "^1.5.3",
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,11 @@ export interface InstallTemplateArgs {
   envEnabled: boolean;
 
   /**
+   * Which library to use for env variables
+   */
+  envLibrary: string;
+
+  /**
    * The template to install
    */
   template: TemplateType;


### PR DESCRIPTION
# feat: env library selection

This adds the flexibility of choosing between `react-native-dotenv` and `react-native-config` for env variables.

## Screenshots

### When not using ENV variables

<img width="486" alt="Screenshot 2024-12-28 at 22 14 49" src="https://github.com/user-attachments/assets/26dfa82a-64bb-4c4a-9191-da943ac7e83d" />

### When using ENV variables

<img width="616" alt="Screenshot 2024-12-28 at 22 10 28" src="https://github.com/user-attachments/assets/64e6f65d-b306-4a2f-9e9d-457ca91324d5" />

### `package.json` after selecting `react-native-config`

<img width="367" alt="Screenshot 2024-12-28 at 22 13 06" src="https://github.com/user-attachments/assets/b5e4f555-f5d0-41f9-8231-b239e370bd8f" />

